### PR TITLE
ci(github-actions): allow manual triggering of the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# .github/workflows/release.yml
+
+name: Praxis CI/CD
+
+# 触发工作流的事件
+on:
+  # *** 新增 ***
+  # 允许您在 GitHub Actions 页面手动触发此工作流
+  workflow_dispatch:
+
+  # 当有代码推送到指定分支时 (保持不变)
+  push:
+    branches:
+      - "main"
+      - "feat/**"
+      - "fix/**"
+      - "dev/**"
+
+  # 当有 Pull Request 提交到 main 分支时 (保持不变)
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org/"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish to NPM
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds the `workflow_dispatch` event to the CI/CD pipeline.

This enables the ability to run the entire test, build, and deployment process on demand from the GitHub Actions UI for any specified branch.